### PR TITLE
Add tests for unary and binary operators

### DIFF
--- a/src/words.c
+++ b/src/words.c
@@ -2095,7 +2095,10 @@ end()
  * Negate each bit of TOS.
  */
 begin(not)
-	peek(sst).v.f = ! peek(sst).v.f;
+	if ( peek(sst).v.f == 0 )
+		peek(sst).v.f = TRUE;
+	else
+		peek(sst).v.f = ~((long)peek(sst).v.f);
 end()
 /**(binary) and
  * Perform bitwise AND on TOS and TOS-1.

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,8 +1,8 @@
 BIN= ../stoical -l ../lib
 
-all: array hash thread unary
+all: array hash thread unary binary
 
-.PHONY: hash array thread unary
+.PHONY: hash array thread unary binary
 
 hash:
 	@$(BIN) $@
@@ -11,4 +11,6 @@ array:
 thread:
 	@$(BIN) $@
 unary:
+	@$(BIN) $@
+binary:
 	@$(BIN) $@

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,12 +1,14 @@
 BIN= ../stoical -l ../lib
 
-all: array hash thread
+all: array hash thread unary
 
-.PHONY: hash array thread
+.PHONY: hash array thread unary
 
-hash: 
+hash:
 	@$(BIN) $@
-array: 
+array:
 	@$(BIN) $@
-thread: 
+thread:
+	@$(BIN) $@
+unary:
 	@$(BIN) $@

--- a/test/binary
+++ b/test/binary
@@ -1,0 +1,141 @@
+#! ../stoical
+
+% Test binary operators
+
+'test load
+
+"Testing binary operators...\n" =
+
+% -----------------
+" + \t% Addition\n" =
+0 0 + 0 eq ok?
+0 1 + 1 eq ok?
+1 1 + 2 eq ok?
+1 -1 + 0 eq ok?
+-1 -1 + -2 eq ok?
+1.1 1.3 + 2.4 - abs 1.0e-6 lt ok?
+
+% -----------------
+" - \t% Subtraction\n" =
+0 0 - 0 eq ok?
+0 1 - -1 eq ok?
+1 1 - 0 eq ok?
+1 -1 - 2 eq ok?
+2 1 - 1 eq ok?
+3.6 1.2 - 2.4 - abs 1.0e-6 lt ok?
+
+% -----------------
+" * \t% Multiplication\n" =
+0 0 * 0 eq ok?
+0 1 * 0 eq ok?
+1 5 * 5 eq ok?
+-1 5 * -5 eq ok?
+-5 -5 * 25 eq ok?
+3.6 1.2 * 4.32 - abs 1.0e-6 lt ok?
+
+% -----------------
+" / \t% Division\n" =
+0 1 / 0 eq ok?
+1 1 / 1 eq ok?
+2 -1 / -2 eq ok?
+10 5 / 2 eq ok?
+-10 -5 / 2 eq ok?
+3.6 1.2 / 3.0 - abs 1.0e-6 lt ok?
+
+% -----------------
+" mod \t% Integer division remainder\n" =
+0 1 mod 0 eq ok?
+1 1 mod 0 eq ok?
+10 4 mod 2 eq ok?
+5.9 3.2 mod 2 eq ok?
+
+% -----------------
+" /mod \t% Integer division quotient and remainder\n" =
+0 1 /mod 0 eq over 0 eq ok? drop
+1 1 /mod 0 eq over 1 eq ok? drop
+10 5 /mod 0 eq over 2 eq ok? drop
+10 4 /mod 2 eq over 2 eq ok? drop
+
+% -----------------
+" lt \t% Is less than\n" =
+0 0 lt false eq ok?
+0 1 lt true eq ok?
+1 5 lt true eq ok?
+-5 -1 lt true eq ok?
+-1 5 lt true eq ok?
+-1.4 3.6 lt true eq ok?
+
+% -----------------
+" gt \t% Is greater than\n" =
+0 0 gt false eq ok?
+1 0 gt true eq ok?
+5 1 gt true eq ok?
+-1 -5 gt true eq ok?
+5 -1 gt true eq ok?
+3.6 -1.4 gt true eq ok?
+
+% -----------------
+" le \t% Is less than or equal\n" =
+0 0 le true eq ok?
+0 1 le true eq ok?
+1 5 le true eq ok?
+5 5 le true eq ok?
+-5 -1 le true eq ok?
+-5 -5 le true eq ok?
+-1.4 3.6 le true eq ok?
+-1.4 -1.4 le true eq ok?
+
+% -----------------
+" ge \t% Is greater than or equal\n" =
+0 0 ge true eq ok?
+1 0 ge true eq ok?
+5 1 ge true eq ok?
+5 5 ge true eq ok?
+-1 -5 ge true eq ok?
+-1 -1 ge true eq ok?
+5 -1 ge true eq ok?
+3.6 -1.4 ge true eq ok?
+3.6 3.6 ge true eq ok?
+
+% -----------------
+" feq \t% Is equal\n" =
+0 0 feq true eq ok?
+0 1 feq false eq ok?
+5 1 feq false eq ok?
+-5 -5 feq true eq ok?
+-5 -1 feq false eq ok?
+1.3 1.3 feq true eq ok?
+
+% -----------------
+" fne \t% Is not equal\n" =
+0 0 fne false eq ok?
+0 1 fne true eq ok?
+5 1 fne true eq ok?
+-5 -5 fne false eq ok?
+-5 -1 fne true eq ok?
+1.3 3.5 fne true eq ok?
+1.3 1.3 fne false eq ok?
+-1.3 3.5 fne true eq ok?
+
+% -----------------
+" and \t% Bitwise and\n" =
+0 0 and 0 eq ok?
+0 1 and 0 eq ok?
+2 1 and 0 eq ok?
+3 1 and 1 eq ok?
+
+% -----------------
+" or \t% Bitwise or\n" =
+0 0 or 0 eq ok?
+0 1 or 1 eq ok?
+2 1 or 3 eq ok?
+3 1 or 3 eq ok?
+
+% -----------------
+" xor \t% Bitwise exclusive or\n" =
+0 0 xor 0 eq ok?
+0 1 xor 1 eq ok?
+2 1 xor 3 eq ok?
+3 1 xor 2 eq ok?
+
+fail @ exit

--- a/test/unary
+++ b/test/unary
@@ -1,0 +1,82 @@
+#! ../stoical
+
+% Test unary operators
+
+'test load
+
+"Testing unary operators...\n" =
+
+% -----------------
+" 1+ \t% Increment\n" =
+0 1+ 1 eq ok?
+1 1+ 2 eq ok?
+-1 1+ 0 eq ok?
+1.5 1+ 2.5 eq ok?
+999998.99 1+ 999999.99 eq ok?
+% ( 's 1+ ) should fail with 'type mismatch' error
+
+% -----------------
+" 1- \t% Decrement\n" =
+0 1- -1 eq ok?
+1 1- 0 eq ok?
+-1 1- -2 eq ok?
+1.5 1- 0.5 eq ok?
+999998.99 1- 999997.99 eq ok?
+
+% -----------------
+" int \t% Floor a float to integer\n" =
+0 int 0 eq ok?
+1 int 1 eq ok?
+0.3 int 0 eq ok?
+0.5 int 0 eq ok?
+1.1 int 1 eq ok?
+1.5 int 1 eq ok?
+-1.5 int -1 eq ok?
+-0.3 int 0 eq ok?
+
+% -----------------
+" abs \t% Absolute value\n" =
+0 abs 0 eq ok?
+-0 abs 0 eq ok?
+-1 abs 1 eq ok?
+-1.5 abs 1.5 eq ok?
+
+% -----------------
+" bool \t% Convert to true/false\n" =
+0 bool false eq ok?
+1 bool true eq ok?
+-1 bool true eq ok?
+3 bool true eq ok?
+-3 bool true eq ok?
+
+% -----------------
+" not \t% Logical complement\n" =
+false not true eq ok?
+true not false eq ok?
+0 not true eq ok?
+1 not false eq ok?
+-1 not false eq ok?
+3 not false eq ok?
+-3 not false eq ok?
+1.3 not false eq ok?
+
+% -----------------
+" eqz \t% Is equal to 0\n" =
+0 eqz true eq ok?
+1 eqz false eq ok?
+-1 eqz false eq ok?
+1.5 eqz false eq ok?
+false eqz true eq ok?
+true eqz false eq ok?
+
+% -----------------
+" ltz \t% Is less than 0\n" =
+0 ltz false eq ok?
+-1 ltz true eq ok?
+-1.5 ltz true eq ok?
+1 ltz false eq ok?
+1.5 ltz false eq ok?
+false ltz false eq ok?
+true ltz true eq ok?
+
+fail @ exit

--- a/test/unary
+++ b/test/unary
@@ -50,15 +50,16 @@
 -3 bool true eq ok?
 
 % -----------------
-" not \t% Logical complement\n" =
+" not \t% Bitwise not\n" =
 false not true eq ok?
 true not false eq ok?
-0 not true eq ok?
-1 not false eq ok?
--1 not false eq ok?
-3 not false eq ok?
--3 not false eq ok?
-1.3 not false eq ok?
+0 not -1 eq ok?
+1 not -2 eq ok?
+-1 not 0 eq ok?
+3 not -4 eq ok?
+-3 not 2 eq ok?
+-1.3 not 0 eq ok?
+-3.3 not 2 eq ok?
 
 % -----------------
 " eqz \t% Is equal to 0\n" =


### PR DESCRIPTION
The tests for unary and binary operators are now added and will run as part of `make test`.

This also changes the implementation of  unary "not" operator, which now performs bitwise-not, which in this context naturally applies to bool and integer values. Floating-point values first being cast into integer type before applying bitwise-not.