### PR TITLE
Add tests for literals and fix the string literal handling

### DIFF
--- a/src/words.c
+++ b/src/words.c
@@ -2825,6 +2825,16 @@ begin(l_)
 	ip = (struct voc_entry **)(a + 1);
 	ip--;
 
+	if ( a->type == T_STR )
+	{
+		string *s;
+		/* string must be copied and therefore protected
+		 * from the garbage collector. */
+
+		s = stringdup(a->v.s);
+		a->v.s = s;
+	}
+
 	push(sst,*a);
 end()
 #ifdef REGEX

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,14 +1,16 @@
 BIN= ../stoical -l ../lib
 
-all: array hash thread unary binary
+all: array hash thread literal unary binary
 
-.PHONY: hash array thread unary binary
+.PHONY: hash array thread literal unary binary
 
 hash:
 	@$(BIN) $@
 array:
 	@$(BIN) $@
 thread:
+	@$(BIN) $@
+literal:
 	@$(BIN) $@
 unary:
 	@$(BIN) $@

--- a/test/literal
+++ b/test/literal
@@ -1,0 +1,27 @@
+#! ../stoical
+
+% Test literals
+
+'test load
+
+"Testing literals...\n" =
+
+% -----------------
+" f \t% Number literal\n" =
+1
+1 eq ok?
+1
+2
+2 eq over 1 eq ok? drop
+1.6
+1.6 eq ok?
+
+% -----------------
+" s \t% String literal\n" =
+'one
+'one eq ok?
+'one
+'two
+'two eq over 'one $eq ok? drop
+
+fail @ exit


### PR DESCRIPTION
This adds tests for literals (numbers and strings) to the project test suite.

Also fixed is some latent issue with string literal handling which manifested itself in some corrupted contents output for any valid string pushed onto stack. Turns out the originally entered into the instruction string would get [properly] garbage collected after execution. So the string needs to be duplicated before getting pushed into the stack.