### PR TITLE
Add tests for string handling and fix some instances of uninitialized var use

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -80,7 +80,7 @@ struct voc_entry ***bstmin	= &bstack[4];
 rcell *rst			= &rstack[4];
 rcell *rstmin			= &rstack[4];
 ccell *ccstmin			= &ccstack[4];
-unsigned char gst;
+unsigned char gst		= 0;
 
 
 /* Declare keyboard buffer and scratch pad space */

--- a/src/signal.c
+++ b/src/signal.c
@@ -52,7 +52,8 @@ void sig_init ( void )
 
 	act.sa_sigaction = sig_segv_h;
 	act.sa_flags	 = SA_SIGINFO;
-	
+	sigemptyset(&(act.sa_mask));
+
 	sigaction( SIGSEGV, &act, NULL ); 
 }
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,9 +1,11 @@
 BIN= ../stoical -l ../lib
 
-all: array hash thread literal unary binary
+all: string array hash thread literal unary binary
 
-.PHONY: hash array thread literal unary binary
+.PHONY: string array thread literal unary binary
 
+string:
+	@$(BIN) $@
 hash:
 	@$(BIN) $@
 array:

--- a/test/string
+++ b/test/string
@@ -1,0 +1,61 @@
+#! ../stoical
+
+% Test strings
+
+'test load
+
+"Testing strings...\n" =
+
+% -----------------
+" msg \t% Print\n" =
+% true ok?
+
+% -----------------
+" $eq \t% Is equal\n" =
+'a 'a $eq true eq ok?
+'one 'one $eq true eq ok?
+'One 'one $eq false eq ok?
+'ONE 'one $eq false eq ok?
+
+% -----------------
+" $eq \t% Is not equal\n" =
+'one 'notone $ne true eq ok?
+'one 'one $ne false eq ok?
+
+% -----------------
+" cat \t% Concatenation\n" =
+'one 'two cat 'onetwo eq ok?
+'one 'two 'three cat cat 'onetwothree eq ok?
+
+% -----------------
+" count \t% String length and pointer\n" =
+'one count 3 eq ok?
+"!not tested: count % test the presence of pointer at TOS-1\n" =
+
+% -----------------
+" type \t% Print string from its count\n" =
+"!not tested: type % test printed output at TOS\n" =
+
+% -----------------
+" stype \t% Recreate string from its count\n" =
+'one count stype 'one eq ok?
+
+% -----------------
+" iliteral \t% String to number\n" =
+'42 iliteral true eq over 42 eq ok? drop
+'1.23 iliteral true eq over 1.23 eq ok? drop
+'abc iliteral false eq ok?
+
+% -----------------
+" word \t% Next word\n" =
+word "abc" 'abc eq eq ok?
+word "  abc" "  abc" eq eq ok?
+"!not tested: word % leading whitespace stripping\n" =
+
+% -----------------
+" ascii \t% Next ASCII char\n" =
+ascii * 42 eq ok?
+ascii 1 49 eq ok?
+ascii 123 49 eq ok?
+
+fail @ exit


### PR DESCRIPTION
Tests for string handling; some behavior is not covered (reported as  `!not tested`) -- not sure yet how this could be scripted, if at all, but manually that seems to function as defined.

Also added a few fixes for uninitialized variable use, as flagged by Valgrind -- these are the easiest issues to fix, unlike hunting down the leaks, which indeed are present, though not too many... Well, one step at a time.

Learning a lot about the language. Still puzzled as for the practical use of pointer values on stack (like from `count` word), other than wrap it back up into a string (by `stype` word):

```
(0)-> 'foo count
(0)-> stack
pointer(0x557c6ca28824) 3

(0)-> stype
(0)-> stack
'foo 
```
Could those pointer values be manipulated directly too? How? Why?