### PR TITLE
Add tests for constants and more fixes for segfaults

### DIFF
--- a/src/words.c
+++ b/src/words.c
@@ -2383,6 +2383,9 @@ end()
  * Print a source version of the word addressed by TOS.
  */
 begin(decompile)
+	if ( peek(sst).type != T_REF )
+		error("invalid address pointer\n");
+
 	st_decompile( ppop(sst), NULL );
 end()
 /**(compiler) vstack (new)

--- a/src/words.c
+++ b/src/words.c
@@ -1049,7 +1049,10 @@ begin(cat)
 	string *s;
 	string *one;
 	string *two;
-	
+
+	if ( peek(sst).type != T_STR || idx(sst,1).type != T_STR )
+		exec(*adr(badtype));
+
 	two = spop(sst);
 	one = spop(sst);
 	len = one->l + two->l;

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -1,10 +1,12 @@
 BIN= ../stoical -l ../lib
 
-all: string array hash thread literal unary binary
+all: string constant array hash thread literal unary binary
 
-.PHONY: string array thread literal unary binary
+.PHONY: string constant array thread literal unary binary
 
 string:
+	@$(BIN) $@
+constant:
 	@$(BIN) $@
 hash:
 	@$(BIN) $@

--- a/test/constant
+++ b/test/constant
@@ -1,0 +1,14 @@
+#! ../stoical
+
+% Test constants
+
+'test load
+
+"Testing constants...\n" =
+
+% -----------------
+"  \t% Pre-defined constants\n" =
+true -1 eq ok?
+false 0 eq ok?
+
+fail @ exit


### PR DESCRIPTION
This adds tests for constants to run as part of project's test suite.

Also enforced the argument type check for "cat" and "decompile" words -- this fixes segfaulting when trying to execute these words with a wrong arg type. 